### PR TITLE
add timeout for request auth server in config

### DIFF
--- a/config/laravel-api-user-provider.php
+++ b/config/laravel-api-user-provider.php
@@ -119,7 +119,7 @@ return [
     */
 
     'password_timeout' => 10800,
-
+    'TimeoutForRequestAuthServer'=>2,
     'base-url'=>'localhost',
 
 ];

--- a/src/LaravelApiUserProviderServiceProvider.php
+++ b/src/LaravelApiUserProviderServiceProvider.php
@@ -32,7 +32,7 @@ class LaravelApiUserProviderServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->bind(HttpClient::class, function ($app) {
-            return $app->makeWith(GuzzelHttpClient::class, ['baseUrl' => $this->getBaseUrl()]);
+            return $app->makeWith(GuzzelHttpClient::class, ['baseUrl' => $this->getBaseUrl(),"timeout"=>$this->getTimeoutRequestToAuthServer()]);
         });
         $this->app->bind(DeserializerInterface::class, function ($app) {
             return $app->make(Deserializer::class);
@@ -68,6 +68,10 @@ class LaravelApiUserProviderServiceProvider extends ServiceProvider
     protected function getBaseUrl()
     {
         return $this->app['config']['auth.base-url'];
+    }
+
+    protected function getTimeoutRequestToAuthServer(){
+        return $this->app["config"]['auth.TimeoutForRequestAuthServer'];
     }
 
     /**

--- a/src/interactModule/GuzzelHttpClient.php
+++ b/src/interactModule/GuzzelHttpClient.php
@@ -22,11 +22,11 @@ class GuzzelHttpClient implements HttpClient
      * GuzzelHttpClient constructor.
      * @param string $baseUrl
      */
-    public function __construct($baseUrl)
+    public function __construct($baseUrl,$timeout)
     {
         $this->client = new Client([
             'base_uri' => $baseUrl,
-            'timeout' => 2.0,
+            'timeout' => $timeout,
         ]);
     }
 


### PR DESCRIPTION
On my local server, because the internet speed was low, the following error was displayed. So I made these changes

`"message": "cURL error 28: Operation timed out after 2000 milliseconds with 0 bytes received `